### PR TITLE
Added null checker to object[key] during filter/search and casted it to String to avoid errors

### DIFF
--- a/lwc/datatable/datatable.js
+++ b/lwc/datatable/datatable.js
@@ -192,7 +192,7 @@ export default class Datatable extends LightningElement {
         if (fieldName == 'all') {
             filteredItems = this.dataCollection.filter(o => Object.keys(o).some(k => o[k] && String(o[k]).toLowerCase().includes(searchTerm)));
         } else {
-            filteredItems = this.dataCollection.filter(result => result[fieldName].toLowerCase().includes(searchTerm));
+            filteredItems = this.dataCollection.filter(result => result[fieldName] && String(result[fieldName]).toLowerCase().includes(searchTerm));
         }
         this.filteredRecordHolder = filteredItems;
         let filteredRecords = Object.assign([], filteredItems);

--- a/lwc/datatable/datatable.js
+++ b/lwc/datatable/datatable.js
@@ -190,7 +190,7 @@ export default class Datatable extends LightningElement {
     dataFilter(fieldName, searchTerm) {
         let filteredItems = [];
         if (fieldName == 'all') {
-            filteredItems = this.dataCollection.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(searchTerm)));
+            filteredItems = this.dataCollection.filter(o => Object.keys(o).some(k => o[k] && String(o[k]).toLowerCase().includes(searchTerm)));
         } else {
             filteredItems = this.dataCollection.filter(result => result[fieldName].toLowerCase().includes(searchTerm));
         }


### PR DESCRIPTION
When performing search, ideally the data will be filtered based on the current serchTerm, however if the data for each row is empty or not casted to string, it basically throws this error:

> o[k].toLowerCase is not a function

a simple solution would be to add conditions to the filter and cast the data to string

From:
`filteredItems = this.dataCollection.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(searchTerm)));`

To:
`filteredItems = this.dataCollection.filter(o => Object.keys(o).some(k => o[k] && String(o[k]).toLowerCase().includes(searchTerm)));`